### PR TITLE
Fix sqflite dependency

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,23 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:webauthn/webauthn.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite/sqflite.dart';
 
 void main() {
+  if (Platform.isWindows || Platform.isLinux) {
+    // Initialize FFI
+    sqfliteFfiInit();
+  }
+
+  // Change the default factory. On iOS/Android, if not using `sqlite_flutter_lib` you can forget
+  // this step, it will use the sqlite version available on the system.
+  databaseFactory = databaseFactoryFfi;
+
   runApp(const MyApp());
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -428,19 +428,33 @@ packages:
     source: hosted
     version: "1.9.0"
   sqflite:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0+1"
+    version: "2.2.0+3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0+2"
+  sqflite_common_ffi:
+    dependency: "direct main"
+    description:
+      name: sqflite_common_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0+1"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -541,4 +555,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.1 <3.0.0"
-  flutter: ">=3.3.0-0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   webauthn:
     path: '../'
+  sqflite_common_ffi: ^2.2.0+1
+  sqflite: ^2.2.0+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
A fix for platform dependency errors with sqflite when running the example project on Windows or Linux. Pull request adds two package dependencies, dart:io import, and initialization code in the main method. 