### PR TITLE
bug(#8): fixing broken keys being returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0
+
+* Updating byte_extensions to 0.0.3 to fix broken keys
+* Base64 URL encoded strings no longer contain trailing '='
+* Adding helper methods base64Encode/Decode to WebAPI
+* Updating example app to use WebAPI.base64 helpers
+
 ## 0.1.0
 
 * Adding support for packed attestations when a new credential is created

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -189,12 +189,15 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: const Text('Create'),
                 ),
                 const SizedBox(width: 30),
-                TextButton(onPressed: () async {
-                  final data = await Clipboard.getData('text/plain');
-                  if (data != null && data.text != null) {
-                    _optionsController.text = data.text!;
-                  }
-                }, child: const Text('From Clipboard'),),
+                TextButton(
+                  onPressed: () async {
+                    final data = await Clipboard.getData('text/plain');
+                    if (data != null && data.text != null) {
+                      _optionsController.text = data.text!;
+                    }
+                  },
+                  child: const Text('From Clipboard'),
+                ),
                 const SizedBox(width: 30),
                 TextButton(
                   onPressed: () {
@@ -240,7 +243,7 @@ class _MyHomePageState extends State<MyHomePage> {
         });
         _startResetSelection();
 
-        return credential;// attestation.getCredentialIdBase64();
+        return credential; // attestation.getCredentialIdBase64();
       } on AuthenticatorException catch (e) {
         _snackBar('Attestation error: ${e.message}');
         return null;
@@ -293,8 +296,8 @@ class _MyHomePageState extends State<MyHomePage> {
                         'rawId': credentialId,
                         'response': {
                           'clientDataJSON': '',
-                          'attestationObject':
-                              base64Url.encode(credential.attestation.asCBOR()),
+                          'attestationObject': WebAPI.base64Encode(
+                              credential.attestation.asCBOR()),
                         },
                       });
 
@@ -347,7 +350,8 @@ class _MyHomePageState extends State<MyHomePage> {
         final options = GetAssertionOptions.fromJson(json.decode(optionsJson));
 
         final assertion = await _auth.getAssertion(options);
-        final credentialId = base64Url.encode(assertion.selectedCredentialId);
+        final credentialId =
+            WebAPI.base64Encode(assertion.selectedCredentialId);
         final credentialIdx = _credentials.indexWhere(
             (e) => e.attestation.getCredentialIdBase64() == credentialId);
 
@@ -365,7 +369,7 @@ class _MyHomePageState extends State<MyHomePage> {
     });
 
     if (assertion != null) {
-      final credentialId = base64Url.encode(assertion.selectedCredentialId);
+      final credentialId = WebAPI.base64Encode(assertion.selectedCredentialId);
       _snackBar('Assertion succeeded for: $credentialId');
       _showAssertionDetails(assertion);
     }
@@ -373,14 +377,15 @@ class _MyHomePageState extends State<MyHomePage> {
 
   void _showAssertionDetails(Assertion assertion) {
     final assertionResponse = {
-      'id': base64Url.encode(assertion.selectedCredentialId),
-      'rawId': base64Url.encode(assertion.selectedCredentialId),
+      'id': WebAPI.base64Encode(assertion.selectedCredentialId),
+      'rawId': WebAPI.base64Encode(assertion.selectedCredentialId),
       'type': 'public-key',
       'response': {
-        'authenticatorData': base64Url.encode(assertion.authenticatorData),
+        'authenticatorData': WebAPI.base64Encode(assertion.authenticatorData),
         'clientDataJSON': '',
-        'signature': base64Url.encode(assertion.signature),
-        'userHandle': base64Url.encode(assertion.selectedCredentialUserHandle),
+        'signature': WebAPI.base64Encode(assertion.signature),
+        'userHandle':
+            WebAPI.base64Encode(assertion.selectedCredentialUserHandle),
       },
     };
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: byte_extensions
-      sha256: c76efdf03c670e5d28795134c759c1c7fbf764856e9a93ec8f5edb56371365d4
+      sha256: d69db1bb5926638d937f2382fe7ad97772e61a4fb842a3143d1510224666385c
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   cbor:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   win32:
     dependency: transitive
     description:

--- a/lib/src/db/credential.dart
+++ b/lib/src/db/credential.dart
@@ -1,7 +1,7 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import '../enums/public_key_credential_type.dart';
+import '../helpers/base64.dart';
 import '../helpers/random.dart';
 import 'db.dart';
 import 'schema.dart';
@@ -92,7 +92,7 @@ class Credential extends SchemaObject {
     this.strongboxRequired,
   ) : super(null) {
     keyId = RandomHelper.nextBytes(32);
-    keyPairAlias = _keyPairPrefix + base64Url.encode(keyId.toList());
+    keyPairAlias = _keyPairPrefix + b64e(keyId.toList());
     keyUseCounter = 0;
   }
 

--- a/lib/src/helpers/base64.dart
+++ b/lib/src/helpers/base64.dart
@@ -1,4 +1,13 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 String padBase64(String b64) {
   final padding = 4 - b64.length % 4;
   return padding < 4 ? '$b64${"=" * padding}' : b64;
 }
+
+/// Decode a Base64 URL encoded string adding in any required '='
+Uint8List b64d(String b64) => base64Url.decode(padBase64(b64));
+
+/// Encode a byte list into Base64 URL encoding, stripping any trailing '='
+String b64e(List<int> bytes) => base64Url.encode(bytes).replaceAll('=', '');

--- a/lib/src/models/assertion_response.dart
+++ b/lib/src/models/assertion_response.dart
@@ -1,10 +1,10 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:webauthn/src/models/converters/uint8list_converter.dart';
 
 import '../enums/public_key_credential_type.dart';
+import '../helpers/base64.dart';
+import '../models/converters/uint8list_converter.dart';
 import 'assertion_response_data.dart';
 
 part 'generated/assertion_response.g.dart';
@@ -21,7 +21,7 @@ class AssertionResponse {
     required this.rawId,
     required this.type,
     required this.response,
-  }) : id = base64Url.encode(rawId);
+  }) : id = b64e(rawId);
 
   factory AssertionResponse.fromJson(Map<String, dynamic> json) =>
       _$AssertionResponseFromJson(json);

--- a/lib/src/models/assertion_response_data.dart
+++ b/lib/src/models/assertion_response_data.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:webauthn/src/models/converters/uint8list_converter.dart';
+
+import 'converters/uint8list_converter.dart';
 
 part 'generated/assertion_response_data.g.dart';
 

--- a/lib/src/models/attestation.dart
+++ b/lib/src/models/attestation.dart
@@ -1,5 +1,6 @@
-import 'dart:convert';
 import 'dart:typed_data';
+
+import '../helpers/base64.dart';
 
 /// This is an attestation that you own the private key for the give
 /// credentialId that is in the authData. The public key is included
@@ -41,6 +42,6 @@ abstract class Attestation {
   /// it to a string.
   /// @see Figure 5 is helpful: https://www.w3.org/TR/webauthn/#attestation-object
   String getCredentialIdBase64() {
-    return base64Url.encode(getCredentialId());
+    return b64e(getCredentialId());
   }
 }

--- a/lib/src/models/attestation_response.dart
+++ b/lib/src/models/attestation_response.dart
@@ -1,7 +1,8 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
+
+import '../helpers/base64.dart';
 import '../enums/public_key_credential_type.dart';
 import 'attestation_response_data.dart';
 import 'converters/uint8list_converter.dart';
@@ -20,7 +21,7 @@ class AttestationResponse {
     required this.rawId,
     required this.type,
     required this.response,
-  }) : id = base64Url.encode(rawId);
+  }) : id = b64e(rawId);
 
   factory AttestationResponse.fromJson(Map<String, dynamic> json) =>
       _$AttestationResponseFromJson(json);

--- a/lib/src/models/attestations/none_attestation.dart
+++ b/lib/src/models/attestations/none_attestation.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:cbor/cbor.dart';
 
 import '../attestation.dart';
+import '../../helpers/base64.dart';
 import '../../enums/attestation_type.dart';
 
 class NoneAttestation extends Attestation {
@@ -20,7 +21,7 @@ class NoneAttestation extends Attestation {
   @override
   String asJSON() {
     return json.encode({
-      'authData': base64Url.encode(authData),
+      'authData': b64e(authData),
       'fmt': format,
       'attStmt': {},
     });

--- a/lib/src/models/attestations/packed_self_attestation.dart
+++ b/lib/src/models/attestations/packed_self_attestation.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:cbor/cbor.dart';
 
 import '../attestation.dart';
+import '../../helpers/base64.dart';
 import '../../enums/attestation_type.dart';
 import '../../util/webauthn_cryptography.dart';
 
@@ -23,11 +24,11 @@ class PackedSelfAttestation extends Attestation {
   @override
   String asJSON() {
     return json.encode({
-      'authData': base64Url.encode(authData),
+      'authData': b64e(authData),
       'fmt': format,
       'attStmt': {
         'alg': WebauthnCrytography.signingAlgoId,
-        'sig': base64Url.encode(signature),
+        'sig': b64e(signature),
       },
     });
   }

--- a/lib/src/models/collected_client_data.dart
+++ b/lib/src/models/collected_client_data.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:json_annotation/json_annotation.dart';
 
+import '../helpers/base64.dart';
 import 'public_key_credential_creation_options.dart';
 import 'public_key_credential_request_options.dart';
 import 'token_binding.dart';
@@ -32,7 +33,7 @@ class CollectedClientData {
     required PublicKeyCredentialCreationOptions options,
   })  : type = 'webauthn.create',
         crossOrigin = !sameOriginWithAncestor,
-        challenge = base64Url.encode(options.challenge);
+        challenge = b64e(options.challenge);
 
   CollectedClientData.fromCredentialRequestOptions({
     required this.origin,
@@ -40,7 +41,7 @@ class CollectedClientData {
     required PublicKeyCredentialRequestOptions options,
   })  : type = 'webauthn.get',
         crossOrigin = !sameOriginWithAncestor,
-        challenge = base64Url.encode(options.challenge);
+        challenge = b64e(options.challenge);
 
   // TODO tokenBinding (and any other fields) need to be able to be serialized
   // into the "remainder" field. We need to update this to handle remainder
@@ -56,5 +57,5 @@ class CollectedClientData {
   List<int> _hash() => sha256.convert(_encode()).bytes;
   Uint8List hash() => Uint8List.fromList(_hash());
 
-  String hashBase64() => base64Url.encode(_hash());
+  String hashBase64() => b64e(_hash());
 }

--- a/lib/src/models/converters/bytebuffer_converter.dart
+++ b/lib/src/models/converters/bytebuffer_converter.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:json_annotation/json_annotation.dart';
@@ -10,8 +9,8 @@ class ByteBufferConverter extends JsonConverter<ByteBuffer, String> {
   const ByteBufferConverter();
 
   @override
-  ByteBuffer fromJson(String json) => base64Url.decode(padBase64(json)).buffer;
+  ByteBuffer fromJson(String json) => b64d(json).buffer;
 
   @override
-  String toJson(ByteBuffer object) => base64Url.encode(object.asInt8List());
+  String toJson(ByteBuffer object) => b64e(object.asInt8List());
 }

--- a/lib/src/models/converters/uint8list_converter.dart
+++ b/lib/src/models/converters/uint8list_converter.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -9,8 +8,8 @@ class Uint8ListConverter implements JsonConverter<Uint8List, String> {
   const Uint8ListConverter();
 
   @override
-  Uint8List fromJson(String json) => base64Url.decode(padBase64(json));
+  Uint8List fromJson(String json) => b64d(json);
 
   @override
-  String toJson(Uint8List object) => base64Url.encode(object);
+  String toJson(Uint8List object) => b64e(object);
 }

--- a/lib/src/util/credential_safe.dart
+++ b/lib/src/util/credential_safe.dart
@@ -7,7 +7,6 @@ import 'package:crypto_keys/crypto_keys.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:local_auth/local_auth.dart';
 
-import '../helpers/base64.dart';
 import './webauthn_cryptography.dart';
 import '../db/credential.dart';
 import '../exceptions.dart';
@@ -58,7 +57,7 @@ class CredentialSafe {
       CborBigInt(pub.xCoordinate),
       CborBigInt(pub.yCoordinate),
     ]));
-    await _storage.write(key: alias, value: base64Url.encode(encoded));
+    await _storage.write(key: alias, value: base64.encode(encoded));
 
     return keypair;
   }
@@ -67,8 +66,7 @@ class CredentialSafe {
   Future<KeyPair?> _loadKeyPairFromAlias(String alias) async {
     final encoded = await _storage.read(key: alias);
     if (encoded != null) {
-      final cborList =
-          cbor.decode(base64Url.decode(padBase64(encoded))) as CborList;
+      final cborList = cbor.decode(base64.decode(encoded)) as CborList;
       final eccPrivateKey = cborList[0].toObject() as BigInt;
       final pk = EcPrivateKey(
         eccPrivateKey: eccPrivateKey,

--- a/lib/src/web_api.dart
+++ b/lib/src/web_api.dart
@@ -1,7 +1,10 @@
+import 'dart:typed_data';
+
 import 'package:local_auth/local_auth.dart';
 
 import 'enums/public_key_credential_type.dart';
 import 'exceptions.dart';
+import 'helpers/base64.dart';
 import 'models/assertion.dart';
 import 'models/assertion_response.dart';
 import 'models/assertion_response_data.dart';
@@ -22,6 +25,12 @@ class WebAPI {
       : _localAuth = localAuth ?? LocalAuthentication();
 
   final LocalAuthentication _localAuth;
+
+  // Decode a base64 string into its bytes per the WebAuthn standard
+  static Uint8List base64Decode(String base64) => b64d(base64);
+
+  /// Encode a byte list into base64 per the WebAuthn standard
+  static String base64Encode(List<int> bytes) => b64e(bytes);
 
   /// Perform portions of the internal Create operations. This will help to
   /// convert the options received from the relying party for use with

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webauthn
 description: A plugin implementing the WebAuthn authenticator model for generating Public Key Credentials
-version: 0.1.0
+version: 0.2.0
 homepage:
 repository: https://github.com/flutter-institute/webauthn
 issue_tracker: https://github.com/flutter-institute/webauthn/issues
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  byte_extensions: ^0.0.2
+  byte_extensions: ^0.0.3
   cbor: ^5.1.2
   collection: ^1.17.1
   crypto: ^3.0.3

--- a/test/authenticator_test.dart
+++ b/test/authenticator_test.dart
@@ -184,7 +184,7 @@ void main() {
     validateAttestationMap(cborEncoded);
 
     final jsonEncoded = json.decode(attObj.asJSON());
-    jsonEncoded['authData'] = base64.decode(jsonEncoded['authData']);
+    jsonEncoded['authData'] = WebAPI.base64Decode(jsonEncoded['authData']);
     validateAttestationMap(jsonEncoded);
 
     final credentialId = attObj.getCredentialId();
@@ -245,9 +245,9 @@ void main() {
     validateAttestationMap(cborEncoded);
 
     final jsonEncoded = json.decode(attObj.asJSON());
-    jsonEncoded['authData'] = base64.decode(jsonEncoded['authData']);
+    jsonEncoded['authData'] = WebAPI.base64Decode(jsonEncoded['authData']);
     jsonEncoded['attStmt']['sig'] =
-        base64.decode(jsonEncoded['attStmt']['sig']);
+        WebAPI.base64Decode(jsonEncoded['attStmt']['sig']);
     validateAttestationMap(jsonEncoded);
 
     final credentialId = attObj.getCredentialId();

--- a/test/models/collected_client_data_test.dart
+++ b/test/models/collected_client_data_test.dart
@@ -24,6 +24,6 @@ void main() {
 
   test('hashes correctly', () {
     final result = clientData.hashBase64();
-    expect(result, equals('NZRNv3PooBe9wyw7h-jHg-LramAlclxZnTQA2k6jMmc='));
+    expect(result, equals('NZRNv3PooBe9wyw7h-jHg-LramAlclxZnTQA2k6jMmc'));
   });
 }

--- a/test/models/create_credential_options_test.dart
+++ b/test/models/create_credential_options_test.dart
@@ -92,11 +92,11 @@ void main() {
     expect(
         joptions['user'],
         equals({
-          'id': 'BgcICQA=',
+          'id': 'BgcICQA',
           'name': pk.userEntity.name,
           'displayName': pk.userEntity.displayName,
         }));
-    expect(joptions['challenge'], equals('AQIDBA=='));
+    expect(joptions['challenge'], equals('AQIDBA'));
     expect(
         joptions['pubKeyCredParams'],
         equals([

--- a/test/models/make_credential_options_test.dart
+++ b/test/models/make_credential_options_test.dart
@@ -81,13 +81,13 @@ void main() {
           'credTypesAndPubKeyAlgs',
           'excludeCredentials',
         ]));
-    expect(json['clientDataHash'], equals('AQIDBAU='));
+    expect(json['clientDataHash'], equals('AQIDBAU'));
     expect(json['rp'],
         equals({'id': options.rpEntity.id, 'name': options.rpEntity.name}));
     expect(
         json['user'],
         equals({
-          'id': 'BgcICQA=',
+          'id': 'BgcICQA',
           'displayName': options.userEntity.displayName,
           'name': options.userEntity.name
         }));

--- a/test/web_api_test.dart
+++ b/test/web_api_test.dart
@@ -1,5 +1,3 @@
-
-
 import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
@@ -64,7 +62,6 @@ void main() {
     when(mockLocalAuth.isDeviceSupported()).thenAnswer((_) async => true);
   });
 
-
   group('create credential options', () {
     late CreateCredentialOptions options;
 
@@ -81,7 +78,7 @@ void main() {
       expect(clientData.type, 'webauthn.create');
       expect(clientData.origin, equals('example.com'));
       expect(clientData.crossOrigin, equals(false));
-      expect(clientData.challenge, equals('AQIDBA=='));
+      expect(clientData.challenge, equals('AQIDBA'));
       expect(clientData.tokenBinding, isNull);
 
       expect(creds.clientDataHash, equals(clientData.hash()));
@@ -229,7 +226,7 @@ void main() {
       expect(clientData.type, 'webauthn.get');
       expect(clientData.origin, equals('example.com'));
       expect(clientData.crossOrigin, equals(false));
-      expect(clientData.challenge, equals('AQIDBA=='));
+      expect(clientData.challenge, equals('AQIDBA'));
       expect(clientData.tokenBinding, isNull);
 
       expect(creds.clientDataHash, equals(clientData.hash()));


### PR DESCRIPTION
Updating byte_extensions to 0.0.3 to fix broken keys Base64 URL encoded strings no longer contain trailing '=' Adding helper methods base64Encode/Decode to WebAPI Updating example app to use WebAPI.base64 helpers